### PR TITLE
タスク一覧の表示とタスクの新規作成

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -44,3 +44,4 @@ app.*.map.json
 # Firebase Setting
 android/app/google-services.json
 ios/Runner/GoogleService-Info.plist
+.firebaserc

--- a/README.md
+++ b/README.md
@@ -4,20 +4,32 @@ flutter を用いて、以下の実装を試したサンプルアプリケーシ
 
 TODO スクショ
 
-実装済み
-- firebase を 用いた SNS ログイン
-    - facebook（android/ios）
-
-未実装
-
-- firebase を 用いた SNS ログイン
-    - google（android/ios）
-
 
 ## ローカル環境の設定
+
+### Firebase の Authentication
 
 - Firebase の設定ファイルは自身で作成したものを配置してください
     - android: `google-services.json` を `android/app/` 配下に配置
     ![android_setting](./README/firebase_setting_android.jpg)
     - ios: `google-services.json` を `android/app/` 配下に配置
     ![android_setting](./README/firebase_setting_ios.jpg)
+
+
+### Firestore 
+
+- ローカル開発時にエミュレータを利用する場合は以下を実施します。
+
+1. firebase CLI のインストール
+2. firebase プロジェクトとしての初期化
+
+```shell
+$ cd /path/to/thisproject
+$ fireabase init
+```
+
+3. ローカルでのエミュレータ起動
+
+```shell
+$ firebase emulators:start
+```

--- a/firebase.json
+++ b/firebase.json
@@ -1,0 +1,12 @@
+{
+  "emulators": {
+    "firestore": {
+      "port": 8080
+    },
+    "ui": {
+      "enabled": true,
+      "host": "localhost",
+      "port": 4000
+    }
+  }
+}

--- a/lib/controllers/login_controller/login_controller.dart
+++ b/lib/controllers/login_controller/login_controller.dart
@@ -26,6 +26,7 @@ class LoginController extends StateNotifier<LoginState> {
       return;
     }
 
+    // FIXME ここで初期化するのがイマイチなので、main.dart のどこかでやるように変えたい
     await Firebase.initializeApp();
     _firebaseAuth = FirebaseAuth.instance;
 

--- a/lib/controllers/tasks_controller/task_controller.dart
+++ b/lib/controllers/tasks_controller/task_controller.dart
@@ -1,0 +1,14 @@
+import 'package:flutter_todo_sample/controllers/tasks_controller/tasks_state.dart';
+import 'package:hooks_riverpod/all.dart';
+
+final tasksProvider = StateNotifierProvider((ref) => TasksController());
+
+class TasksController extends StateNotifier<TasksState> {
+  TasksController() : super(TasksState(tasks: [])) ;
+
+  addTask(String title) {
+    final tasks = [title] + state.tasks;
+    state = state.copyWith(tasks: tasks);
+  }
+
+}

--- a/lib/controllers/tasks_controller/task_controller.dart
+++ b/lib/controllers/tasks_controller/task_controller.dart
@@ -1,14 +1,32 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
 import 'package:flutter_todo_sample/controllers/tasks_controller/tasks_state.dart';
+import 'package:flutter_todo_sample/entities/Task.dart';
 import 'package:hooks_riverpod/all.dart';
 
 final tasksProvider = StateNotifierProvider((ref) => TasksController());
 
 class TasksController extends StateNotifier<TasksState> {
-  TasksController() : super(TasksState(tasks: [])) ;
+  TasksController() : super(TasksState(tasks: [])) {
 
-  addTask(String title) {
-    final tasks = [title] + state.tasks;
+    final isProduction = bool.fromEnvironment('dart.vm.product');
+    // await Firebase.initializeApp();
+    if (!isProduction) {
+      FirebaseFirestore.instance.settings = Settings(
+          host: 'localhost:8080', sslEnabled: false, persistenceEnabled: false);
+    }
+    loadTask();
+  }
+  final taskCollection = FirebaseFirestore.instance.collection('tasks');
+
+  loadTask() async {
+    final result = await taskCollection.get();
+    final tasks = result.docs.map((d) => Task(title: d.get('title'))).toList();
     state = state.copyWith(tasks: tasks);
+  }
+
+  addTask(String title) async {
+    await taskCollection.add({'title': title});
+    loadTask();
   }
 
 }

--- a/lib/controllers/tasks_controller/tasks_state.dart
+++ b/lib/controllers/tasks_controller/tasks_state.dart
@@ -1,3 +1,4 @@
+import 'package:flutter_todo_sample/entities/Task.dart';
 import 'package:freezed_annotation/freezed_annotation.dart';
 
 part 'tasks_state.freezed.dart';
@@ -7,6 +8,6 @@ abstract class TasksState with _$TasksState{
   TasksState._();
 
   factory TasksState({
-    List<String> tasks
+    List<Task> tasks
   }) = _TasksState;
 }

--- a/lib/controllers/tasks_controller/tasks_state.dart
+++ b/lib/controllers/tasks_controller/tasks_state.dart
@@ -1,0 +1,12 @@
+import 'package:freezed_annotation/freezed_annotation.dart';
+
+part 'tasks_state.freezed.dart';
+
+@freezed
+abstract class TasksState with _$TasksState{
+  TasksState._();
+
+  factory TasksState({
+    List<String> tasks
+  }) = _TasksState;
+}

--- a/lib/controllers/tasks_controller/tasks_state.freezed.dart
+++ b/lib/controllers/tasks_controller/tasks_state.freezed.dart
@@ -1,0 +1,127 @@
+// GENERATED CODE - DO NOT MODIFY BY HAND
+// ignore_for_file: deprecated_member_use, deprecated_member_use_from_same_package, use_function_type_syntax_for_parameters, unnecessary_const, avoid_init_to_null, invalid_override_different_default_values_named, prefer_expression_function_bodies
+
+part of 'tasks_state.dart';
+
+// **************************************************************************
+// FreezedGenerator
+// **************************************************************************
+
+T _$identity<T>(T value) => value;
+
+/// @nodoc
+class _$TasksStateTearOff {
+  const _$TasksStateTearOff();
+
+// ignore: unused_element
+  _TasksState call({List<String> tasks}) {
+    return _TasksState(
+      tasks: tasks,
+    );
+  }
+}
+
+/// @nodoc
+// ignore: unused_element
+const $TasksState = _$TasksStateTearOff();
+
+/// @nodoc
+mixin _$TasksState {
+  List<String> get tasks;
+
+  $TasksStateCopyWith<TasksState> get copyWith;
+}
+
+/// @nodoc
+abstract class $TasksStateCopyWith<$Res> {
+  factory $TasksStateCopyWith(
+          TasksState value, $Res Function(TasksState) then) =
+      _$TasksStateCopyWithImpl<$Res>;
+  $Res call({List<String> tasks});
+}
+
+/// @nodoc
+class _$TasksStateCopyWithImpl<$Res> implements $TasksStateCopyWith<$Res> {
+  _$TasksStateCopyWithImpl(this._value, this._then);
+
+  final TasksState _value;
+  // ignore: unused_field
+  final $Res Function(TasksState) _then;
+
+  @override
+  $Res call({
+    Object tasks = freezed,
+  }) {
+    return _then(_value.copyWith(
+      tasks: tasks == freezed ? _value.tasks : tasks as List<String>,
+    ));
+  }
+}
+
+/// @nodoc
+abstract class _$TasksStateCopyWith<$Res> implements $TasksStateCopyWith<$Res> {
+  factory _$TasksStateCopyWith(
+          _TasksState value, $Res Function(_TasksState) then) =
+      __$TasksStateCopyWithImpl<$Res>;
+  @override
+  $Res call({List<String> tasks});
+}
+
+/// @nodoc
+class __$TasksStateCopyWithImpl<$Res> extends _$TasksStateCopyWithImpl<$Res>
+    implements _$TasksStateCopyWith<$Res> {
+  __$TasksStateCopyWithImpl(
+      _TasksState _value, $Res Function(_TasksState) _then)
+      : super(_value, (v) => _then(v as _TasksState));
+
+  @override
+  _TasksState get _value => super._value as _TasksState;
+
+  @override
+  $Res call({
+    Object tasks = freezed,
+  }) {
+    return _then(_TasksState(
+      tasks: tasks == freezed ? _value.tasks : tasks as List<String>,
+    ));
+  }
+}
+
+/// @nodoc
+class _$_TasksState extends _TasksState {
+  _$_TasksState({this.tasks}) : super._();
+
+  @override
+  final List<String> tasks;
+
+  @override
+  String toString() {
+    return 'TasksState(tasks: $tasks)';
+  }
+
+  @override
+  bool operator ==(dynamic other) {
+    return identical(this, other) ||
+        (other is _TasksState &&
+            (identical(other.tasks, tasks) ||
+                const DeepCollectionEquality().equals(other.tasks, tasks)));
+  }
+
+  @override
+  int get hashCode =>
+      runtimeType.hashCode ^ const DeepCollectionEquality().hash(tasks);
+
+  @override
+  _$TasksStateCopyWith<_TasksState> get copyWith =>
+      __$TasksStateCopyWithImpl<_TasksState>(this, _$identity);
+}
+
+abstract class _TasksState extends TasksState {
+  _TasksState._() : super._();
+  factory _TasksState({List<String> tasks}) = _$_TasksState;
+
+  @override
+  List<String> get tasks;
+  @override
+  _$TasksStateCopyWith<_TasksState> get copyWith;
+}

--- a/lib/controllers/tasks_controller/tasks_state.freezed.dart
+++ b/lib/controllers/tasks_controller/tasks_state.freezed.dart
@@ -14,7 +14,7 @@ class _$TasksStateTearOff {
   const _$TasksStateTearOff();
 
 // ignore: unused_element
-  _TasksState call({List<String> tasks}) {
+  _TasksState call({List<Task> tasks}) {
     return _TasksState(
       tasks: tasks,
     );
@@ -27,7 +27,7 @@ const $TasksState = _$TasksStateTearOff();
 
 /// @nodoc
 mixin _$TasksState {
-  List<String> get tasks;
+  List<Task> get tasks;
 
   $TasksStateCopyWith<TasksState> get copyWith;
 }
@@ -37,7 +37,7 @@ abstract class $TasksStateCopyWith<$Res> {
   factory $TasksStateCopyWith(
           TasksState value, $Res Function(TasksState) then) =
       _$TasksStateCopyWithImpl<$Res>;
-  $Res call({List<String> tasks});
+  $Res call({List<Task> tasks});
 }
 
 /// @nodoc
@@ -53,7 +53,7 @@ class _$TasksStateCopyWithImpl<$Res> implements $TasksStateCopyWith<$Res> {
     Object tasks = freezed,
   }) {
     return _then(_value.copyWith(
-      tasks: tasks == freezed ? _value.tasks : tasks as List<String>,
+      tasks: tasks == freezed ? _value.tasks : tasks as List<Task>,
     ));
   }
 }
@@ -64,7 +64,7 @@ abstract class _$TasksStateCopyWith<$Res> implements $TasksStateCopyWith<$Res> {
           _TasksState value, $Res Function(_TasksState) then) =
       __$TasksStateCopyWithImpl<$Res>;
   @override
-  $Res call({List<String> tasks});
+  $Res call({List<Task> tasks});
 }
 
 /// @nodoc
@@ -82,7 +82,7 @@ class __$TasksStateCopyWithImpl<$Res> extends _$TasksStateCopyWithImpl<$Res>
     Object tasks = freezed,
   }) {
     return _then(_TasksState(
-      tasks: tasks == freezed ? _value.tasks : tasks as List<String>,
+      tasks: tasks == freezed ? _value.tasks : tasks as List<Task>,
     ));
   }
 }
@@ -92,7 +92,7 @@ class _$_TasksState extends _TasksState {
   _$_TasksState({this.tasks}) : super._();
 
   @override
-  final List<String> tasks;
+  final List<Task> tasks;
 
   @override
   String toString() {
@@ -118,10 +118,10 @@ class _$_TasksState extends _TasksState {
 
 abstract class _TasksState extends TasksState {
   _TasksState._() : super._();
-  factory _TasksState({List<String> tasks}) = _$_TasksState;
+  factory _TasksState({List<Task> tasks}) = _$_TasksState;
 
   @override
-  List<String> get tasks;
+  List<Task> get tasks;
   @override
   _$TasksStateCopyWith<_TasksState> get copyWith;
 }

--- a/lib/entities/Task.dart
+++ b/lib/entities/Task.dart
@@ -1,0 +1,4 @@
+class Task {
+  final String title;
+  Task({this.title});
+}

--- a/lib/main.dart
+++ b/lib/main.dart
@@ -1,3 +1,5 @@
+import 'package:cloud_firestore/cloud_firestore.dart';
+import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
 import 'package:flutter_riverpod/flutter_riverpod.dart';
@@ -8,12 +10,14 @@ import 'package:loader_overlay/loader_overlay.dart';
 
 import 'controllers/login_controller/login_controller.dart';
 
-void main() => runApp(
+void main() async {
+
+  runApp(
     const ProviderScope(
       child: MyApp(),
     ),
   );
-
+}
 class MyApp extends HookWidget {
   const MyApp({Key key}) : super(key: key);
   @override
@@ -34,12 +38,12 @@ class MyApp extends HookWidget {
         home: TasksPage(),
       );
     } else {
-        return MaterialApp(
-          home: LoaderOverlay(
-              useDefaultLoading: true,
-              child: LoginPage()
-          ),
-        );
+      return MaterialApp(
+        home: LoaderOverlay(
+            useDefaultLoading: true,
+            child: LoginPage()
+        ),
+      );
     }
   }
 }

--- a/lib/pages/tasks_page/task_modal.dart
+++ b/lib/pages/tasks_page/task_modal.dart
@@ -1,0 +1,51 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/src/widgets/framework.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+import 'package:flutter_todo_sample/controllers/tasks_controller/task_controller.dart';
+import 'package:hooks_riverpod/all.dart';
+
+class TaskModal extends HookWidget {
+  final _titleTextController = TextEditingController();
+
+  @override
+  Widget build(BuildContext context) {
+
+    return Container(
+      margin: EdgeInsets.all(30),
+      child: Column(
+        mainAxisSize: MainAxisSize.min,
+        children: <Widget>[
+          TextField(
+            controller: _titleTextController,
+            decoration: InputDecoration(
+                hintText: 'タスクのタイトル'
+            ),
+          ),
+          ButtonBar(
+            alignment: MainAxisAlignment.spaceAround,
+            children: <Widget>[
+              FlatButton(
+                child: Text('キャンセル'),
+                onPressed: () {
+                  Navigator.of(context).pop(true);
+                },
+              ),
+              RaisedButton(
+                child: Text('保存'),
+                onPressed: () async {
+                  _onSavePressed(context, _titleTextController.text);
+                  Navigator.of(context).pop();
+                },
+              )
+            ],
+          )
+        ],
+      ),
+    );
+  }
+
+  _onSavePressed(BuildContext context, String taskTitle) {
+    context.read(tasksProvider).addTask(taskTitle);
+  }
+
+}

--- a/lib/pages/tasks_page/task_tile.dart
+++ b/lib/pages/tasks_page/task_tile.dart
@@ -1,0 +1,34 @@
+import 'package:flutter/material.dart';
+import 'package:flutter/src/widgets/framework.dart';
+import 'package:flutter_hooks/flutter_hooks.dart';
+
+class TaskTile extends HookWidget {
+
+  final String title;
+  TaskTile(this.title);
+
+  @override
+  Widget build(BuildContext context) {
+    return Container(
+      decoration: new BoxDecoration(
+          border: new Border(bottom: BorderSide(width: 0.5, color: Colors.grey))
+      ),
+      child:ListTile(
+        leading: Icon(Icons.warning_amber_rounded),
+        title: Text(
+          title,
+          style: TextStyle(
+              color:Colors.black,
+              fontSize: 18.0
+          ),
+        ),
+        onTap: () {
+          print("onTap called.");
+        }, // タップ
+        onLongPress: () {
+          print("onLongPress called.");
+        }, // 長押し
+      ),
+    );
+  }
+}

--- a/lib/pages/tasks_page/task_tile.dart
+++ b/lib/pages/tasks_page/task_tile.dart
@@ -14,7 +14,7 @@ class TaskTile extends HookWidget {
           border: new Border(bottom: BorderSide(width: 0.5, color: Colors.grey))
       ),
       child:ListTile(
-        leading: Icon(Icons.warning_amber_rounded),
+        leading: Icon(Icons.radio_button_off),
         title: Text(
           title,
           style: TextStyle(

--- a/lib/pages/tasks_page/tasks_page.dart
+++ b/lib/pages/tasks_page/tasks_page.dart
@@ -1,23 +1,50 @@
 import 'package:flutter/material.dart';
 import 'package:flutter/src/widgets/framework.dart';
 import 'package:flutter_hooks/flutter_hooks.dart';
-import 'package:flutter_todo_sample/pages/login_page/facebook_logout_button.dart';
-import 'package:flutter_todo_sample/pages/login_page/google_logout_button.dart';
+import 'package:flutter_todo_sample/controllers/tasks_controller/task_controller.dart';
+import 'package:flutter_todo_sample/pages/tasks_page/task_modal.dart';
+import 'package:flutter_todo_sample/pages/tasks_page/task_tile.dart';
+import 'package:hooks_riverpod/all.dart';
 
 class TasksPage extends HookWidget {
 
   @override
   Widget build(BuildContext context) {
+
+    final tasks = useProvider(
+        tasksProvider.state.select((_) => _.tasks)
+    );
+
     return Scaffold(
       body: Center(
-        child: Column(
-          mainAxisSize: MainAxisSize.min,
-          children: [
-            Text("タスク一覧"),
-            FacebookLogoutButton(),
-            GoogleLogoutButton(),
-          ]
-        )
+        child:
+          ListView(
+            children: (tasks.map((e) => TaskTile(e))).toList(),
+          )
+      ),
+      floatingActionButton: FloatingActionButton(
+        onPressed: () {
+          showModalBottomSheet(
+            backgroundColor: Colors.transparent,
+            isScrollControlled: true,
+            context: context,
+            builder: (context) =>
+              SingleChildScrollView(
+                child: Container(
+                  decoration: BoxDecoration(
+                    color: Colors.white,
+                    borderRadius: BorderRadius.only(
+                      topLeft: Radius.circular(20),
+                      topRight: Radius.circular(20),
+                    ),
+                  ),
+                  child: SingleChildScrollView(
+                    child: TaskModal()
+                  ),
+                )
+              )
+          );
+        },
       ),
     );
   }

--- a/lib/pages/tasks_page/tasks_page.dart
+++ b/lib/pages/tasks_page/tasks_page.dart
@@ -19,7 +19,7 @@ class TasksPage extends HookWidget {
       body: Center(
         child:
           ListView(
-            children: (tasks.map((e) => TaskTile(e))).toList(),
+            children: (tasks.map((e) => TaskTile(e.title))).toList(),
           )
       ),
       floatingActionButton: FloatingActionButton(

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -127,6 +127,27 @@ packages:
       url: "https://pub.dartlang.org"
     source: hosted
     version: "1.1.0-nullsafety.1"
+  cloud_firestore:
+    dependency: "direct main"
+    description:
+      name: cloud_firestore
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.14.4"
+  cloud_firestore_platform_interface:
+    dependency: transitive
+    description:
+      name: cloud_firestore_platform_interface
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "2.2.1"
+  cloud_firestore_web:
+    dependency: transitive
+    description:
+      name: cloud_firestore_web
+      url: "https://pub.dartlang.org"
+    source: hosted
+    version: "0.2.1+2"
   code_builder:
     dependency: transitive
     description:
@@ -189,42 +210,42 @@ packages:
       name: firebase_auth
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.18.3"
+    version: "0.18.4+1"
   firebase_auth_platform_interface:
     dependency: transitive
     description:
       name: firebase_auth_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.1.3"
+    version: "2.1.4"
   firebase_auth_web:
     dependency: transitive
     description:
       name: firebase_auth_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.3.2"
+    version: "0.3.2+3"
   firebase_core:
     dependency: "direct main"
     description:
       name: firebase_core
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.5.2"
+    version: "0.5.3"
   firebase_core_platform_interface:
     dependency: transitive
     description:
       name: firebase_core_platform_interface
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "2.0.0"
+    version: "2.1.0"
   firebase_core_web:
     dependency: transitive
     description:
       name: firebase_core_web
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "0.2.1"
+    version: "0.2.1+1"
   fixnum:
     dependency: transitive
     description:

--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -39,6 +39,9 @@ dependencies:
   # for use copyWith
   freezed_annotation:
 
+  # firestore
+  cloud_firestore: ^0.14.4
+
 dev_dependencies:
   flutter_test:
     sdk: flutter


### PR DESCRIPTION
以下を含みます ※ローカルのfirestore エミュレータにて
- Firestore から取得したタスクの一覧表示
- タスクを新規登録して、Firestoreにデータを格納する

以下は含みません
- タスクのステータス変更
- タスクの内容変更
- タスクの削除